### PR TITLE
responsible nodes-the old version was still there

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -30,8 +30,6 @@ BaseOptions:
   EdgeLock: true
   # SameOriginator: false, makes the same originator request many times in a row
   SameOriginator: false
-  # PrecomputeRespNodes: true, precomputes responsible nodes for chunks or ad-hoc during run
-  PrecomputeRespNodes: false
   # WriteRoutesToFile: false, writes routes to file for future usage
   WriteRoutesToFile: false
   # WriteStatesToFile: false, writes a subset of states to file for future usage

--- a/config/config_types.go
+++ b/config/config_types.go
@@ -25,7 +25,6 @@ type baseOptions struct {
 	RequestsPerSecond         int           `yaml:"RequestsPerSecond"`
 	EdgeLock                  bool          `yaml:"EdgeLock"`
 	SameOriginator            bool          `yaml:"SameOriginator"`
-	PrecomputeRespNodes       bool          `yaml:"PrecomputeRespNodes"`
 	WriteRoutesToFile         bool          `yaml:"WriteRoutesToFile"`
 	WriteStatesToFile         bool          `yaml:"WriteStatesToFile"`
 	IterationMeansUniqueChunk bool          `yaml:"IterationMeansUniqueChunk"`

--- a/config/default_variables.go
+++ b/config/default_variables.go
@@ -21,7 +21,6 @@ func getDefaultConfig() Config {
 			RequestsPerSecond:         100_000,   // 100_000
 			EdgeLock:                  true,      // false
 			SameOriginator:            false,     // false
-			PrecomputeRespNodes:       false,     // false   //changed to depth option
 			WriteRoutesToFile:         false,     // false
 			WriteStatesToFile:         false,     // false
 			IterationMeansUniqueChunk: false,     // false

--- a/config/get_variables.go
+++ b/config/get_variables.go
@@ -141,10 +141,6 @@ func IsEdgeLock() bool {
 	return theconfig.BaseOptions.EdgeLock
 }
 
-func IsPrecomputeRespNodes() bool {
-	return theconfig.BaseOptions.PrecomputeRespNodes
-}
-
 func IsWriteRoutesToFile() bool {
 	return theconfig.BaseOptions.WriteRoutesToFile
 }

--- a/config/testdata/default_config.yaml
+++ b/config/testdata/default_config.yaml
@@ -30,8 +30,6 @@ BaseOptions:
   EdgeLock: true
   # SameOriginator: false, makes the same originator request many times in a row
   SameOriginator: false
-  # PrecomputeRespNodes: false, precomputes responsible nodes for chunks or ad-hoc during run
-  PrecomputeRespNodes: false
   # WriteRoutesToFile: false, writes routes to file for future usage
   WriteRoutesToFile: false
   # WriteStatesToFile: false, writes a subset of states to file for future usage

--- a/model/parts/types/types.go
+++ b/model/parts/types/types.go
@@ -6,7 +6,6 @@ type Request struct {
 	OriginatorIndex int
 	OriginatorId    NodeId
 	ChunkId         ChunkId
-	// RespNodes       [4]NodeId
 }
 
 type RequestResult struct {

--- a/model/parts/utils/find_route.go
+++ b/model/parts/utils/find_route.go
@@ -12,7 +12,6 @@ func FindDistance(first types.NodeId, second types.ChunkId) int {
 
 func FindRoute(request types.Request, graph *types.Graph) ([]types.NodeId, []types.Payment, bool, bool, bool, bool) {
 	chunkId := request.ChunkId
-	// respNodes := request.RespNodes
 	mainOriginatorId := request.OriginatorId
 	curNextNodeId := request.OriginatorId
 	route := []types.NodeId{
@@ -51,11 +50,6 @@ func FindRoute(request types.Request, graph *types.Graph) ([]types.NodeId, []typ
 					found = true
 					break out
 				}
-				// if general.ArrContains(respNodes, nextNodeId) {
-				// 	//fmt.Println("is not in cache")
-				// 	found = true
-				// 	break out
-				// }
 				if config.IsCacheEnabled() {
 					node := graph.GetNode(nextNodeId)
 					if node.CacheStruct.Contains(chunkId) {
@@ -71,44 +65,6 @@ func FindRoute(request types.Request, graph *types.Graph) ([]types.NodeId, []typ
 			}
 		}
 	}
-
-	// if general.ArrContains(respNodes, mainOriginatorId) {
-	// 	// originator has the chunk --> chunk is found
-	// 	found = true
-	// } else {
-	// out:
-	// 	for !general.ArrContains(respNodes, curNextNodeId) {
-	// 		// fmt.Printf("\n orig: %d, chunk_id: %d", mainOriginatorId, chunkId)
-
-	// 		nextNodeId, thresholdFailed, accessFailed, prevNodePaid, payment = getNext(request, curNextNodeId, prevNodePaid, graph)
-
-	// 		if !payment.IsNil() {
-	// 			paymentList = append(paymentList, payment)
-	// 		}
-	// 		if !nextNodeId.IsNil() {
-	// 			route = append(route, nextNodeId)
-	// 		}
-	// 		if !thresholdFailed && !accessFailed {
-	// 			if general.ArrContains(respNodes, nextNodeId) {
-	// 				//fmt.Println("is not in cache")
-	// 				found = true
-	// 				break out
-	// 			}
-	// 			if config.IsCacheEnabled() {
-	// 				node := graph.GetNode(nextNodeId)
-	// 				if node.CacheStruct.Contains(chunkId) {
-	// 					foundByCaching = true
-	// 					found = true
-	// 					break out
-	// 				}
-	// 			}
-	// 			// NOTE !
-	// 			curNextNodeId = nextNodeId
-	// 		} else {
-	// 			break out
-	// 		}
-	// 	}
-	// }
 
 	if config.IsForwardersPayForceOriginatorToPay() {
 		if !accessFailed && len(paymentList) > 0 {

--- a/model/parts/workers/request_worker.go
+++ b/model/parts/workers/request_worker.go
@@ -16,7 +16,6 @@ func RequestWorker(pauseChan chan bool, continueChan chan bool, requestChan chan
 	var counter = 0
 	var curEpoch = 0
 	var chunkId types.ChunkId
-	// var respNodes [4]types.NodeId
 	iterations := config.GetIterations()
 	numRoutingGoroutines := config.GetNumRoutingGoroutines()
 
@@ -82,7 +81,6 @@ func RequestWorker(pauseChan chan bool, continueChan chan bool, requestChan chan
 					OriginatorIndex: originatorIndex,
 					OriginatorId:    originatorId,
 					ChunkId:         chunkId,
-					// RespNodes:       respNodes,
 				}
 				requestChan <- request
 			}


### PR DESCRIPTION
I removed the finding responsible nodes in the old way but somehow it stayed there after merge. 