### PR TITLE
New features and fixes for the retry option

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -30,6 +30,8 @@ BaseOptions:
   SameOriginator: false
   # IterationMeansUniqueChunk: false, if a chunk chosen again by waiting/retry counts as an iteration
   IterationMeansUniqueChunk: false
+  # RetryCausesTimeIncrease: false, if retry counts towards the x requests an originator makes per second
+  RetryCausesTimeIncrease: false
   # DebugPrints: false, enables some useful prints to terminal during the run
   DebugPrints: true
   # DebugInterval: 1_000_000, how often these prints should be done

--- a/config/config_types.go
+++ b/config/config_types.go
@@ -25,6 +25,7 @@ type baseOptions struct {
 	EdgeLock                    bool          `yaml:"EdgeLock"`
 	SameOriginator              bool          `yaml:"SameOriginator"`
 	IterationMeansUniqueChunk   bool          `yaml:"IterationMeansUniqueChunk"`
+	RetryCausesTimeIncrease     bool          `yaml:"RetryCausesTimeIncrease"`
 	DebugPrints                 bool          `yaml:"DebugPrints"`
 	DebugInterval               int           `yaml:"DebugInterval"`
 	NumGoroutines               int           `yaml:"NumGoroutines"`

--- a/config/default_variables.go
+++ b/config/default_variables.go
@@ -21,6 +21,7 @@ func getDefaultConfig() Config {
 			EdgeLock:                    true,      // false
 			SameOriginator:              false,     // false
 			IterationMeansUniqueChunk:   false,     // false
+			RetryCausesTimeIncrease:     false,     //false
 			DebugPrints:                 false,     // false
 			DebugInterval:               1000000,   // 1000000
 			NumGoroutines:               -1,        // -1 means gets overwritten by numCPU

--- a/config/get_variables.go
+++ b/config/get_variables.go
@@ -151,6 +151,10 @@ func IsIterationMeansUniqueChunk() bool {
 	return theconfig.BaseOptions.IterationMeansUniqueChunk
 }
 
+func RetryCausesTimeIncrease() bool {
+	return theconfig.BaseOptions.RetryCausesTimeIncrease
+}
+
 func IsDebugPrints() bool {
 	return theconfig.BaseOptions.DebugPrints
 }

--- a/config/init_configs.go
+++ b/config/init_configs.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"os"
 	"runtime"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -68,6 +69,7 @@ func ValidateBaseOptions(configOptions baseOptions) {
 	SetEvaluateInterval(configOptions.OutputOptions.EvaluateInterval)
 	SetAddressRange(configOptions.Bits)
 	SetStorageDepth(configOptions.ReplicationFactor)
+	SetRandomSeed()
 }
 
 func SetNumGoroutines(numGoroutines int) {
@@ -77,8 +79,8 @@ func SetNumGoroutines(numGoroutines int) {
 }
 
 func SetEvaluateInterval(interval int) {
-	if interval <= 0 {
-		theconfig.BaseOptions.OutputOptions.EvaluateInterval = theconfig.BaseOptions.Iterations
+	if interval < 0 {
+		theconfig.BaseOptions.OutputOptions.EvaluateInterval = 0
 	}
 }
 
@@ -101,4 +103,10 @@ func SetStorageDepth(replicationFactor int) {
 		depth++
 	}
 	theconfig.BaseOptions.StorageDepth = depth
+}
+
+func SetRandomSeed() {
+	if theconfig.BaseOptions.RandomSeed == -1 {
+		theconfig.BaseOptions.RandomSeed = time.Now().UnixNano()
+	}
 }

--- a/config/testdata/default_config.yaml
+++ b/config/testdata/default_config.yaml
@@ -30,6 +30,8 @@ BaseOptions:
   SameOriginator: false
   # IterationMeansUniqueChunk: false, if a chunk chosen again by waiting/retry counts as an iteration
   IterationMeansUniqueChunk: false
+  # RetryCausesTimeIncrease: false, if retry counts towards the x requests an originator makes per second
+  RetryCausesTimeIncrease: false
   # DebugPrints: false, enables some useful prints to terminal during the run
   DebugPrints: false
   # DebugInterval: 1_000_000, how often these prints should be done

--- a/model/parts/output/income_info.go
+++ b/model/parts/output/income_info.go
@@ -14,7 +14,7 @@ type IncomeInfo struct {
 	IncomeMap  map[int]int
 	HopMap     map[int][]int
 	CostMap    map[int]int
-	Requesters map[int]bool
+	Requesters map[int]int
 	File       *os.File
 	Writer     *bufio.Writer
 }
@@ -24,7 +24,7 @@ func InitIncomeInfo() *IncomeInfo {
 	iinfo.IncomeMap = make(map[int]int)
 	iinfo.CostMap = make(map[int]int)
 	iinfo.HopMap = make(map[int][]int)
-	iinfo.Requesters = make(map[int]bool) //This map is currently used to find out who is an originator. This should instead be looked up somewhere else.
+	iinfo.Requesters = make(map[int]int) //This map is currently used to find out who is an originator. This should instead be looked up somewhere else.
 
 	iinfo.File = MakeFile("./results/income.txt")
 	iinfo.Writer = bufio.NewWriter(iinfo.File)
@@ -36,7 +36,7 @@ func (ii *IncomeInfo) Reset() {
 	ii.IncomeMap = make(map[int]int)
 	ii.CostMap = make(map[int]int)
 	ii.HopMap = make(map[int][]int)
-	ii.Requesters = make(map[int]bool) //This map is currently used to find out who is an originator. This should instead be looked up somewhere else.
+	ii.Requesters = make(map[int]int) //This map is currently used to find out who is an originator. This should instead be looked up somewhere else.
 }
 
 func (ii *IncomeInfo) Close() {
@@ -65,7 +65,7 @@ func (o *IncomeInfo) CalculateNonOIncomeFairness() float64 {
 	size := config.GetNetworkSize()
 	vals := make([]int, 0, size)
 	for id, value := range o.IncomeMap {
-		if !o.Requesters[id] {
+		if o.Requesters[id] == 0 {
 			vals = append(vals, value)
 		}
 	}
@@ -76,8 +76,21 @@ func (o *IncomeInfo) CalculateOriginatorCostFairness() float64 {
 	size := config.GetNetworkSize()
 	vals := make([]int, 0, size)
 	for id, value := range o.CostMap {
-		if o.Requesters[id] {
+		if o.Requesters[id] > 0 {
 			vals = append(vals, value)
+		}
+	}
+	return utils.Gini(vals)
+}
+
+func (o *IncomeInfo) CalculateCostAdjustedOriginatorIncomeFairness() float64 {
+	size := config.GetNetworkSize()
+	vals := make([]int, 0, size)
+	for id, cost := range o.CostMap {
+		if o.Requesters[id] > 0 {
+			income := o.IncomeMap[id]
+			vals = append(vals, income-cost+o.Requesters[id]*16)
+
 		}
 	}
 	return utils.Gini(vals)
@@ -94,14 +107,24 @@ func (o *IncomeInfo) CalculateIncomeTheilIndex() float64 {
 	return utils.Theil(vals)
 }
 
-func (o *IncomeInfo) CalculateNegativeIncome() float64 {
+func (o *IncomeInfo) CalculateNegativeIncome() (float64, float64) {
 	totalNegativeIncomeCounter := 0
-	for _, value := range o.IncomeMap {
+	nonOriNegativeIncomeCounter := 0
+	for id, value := range o.IncomeMap {
 		if value < 0 {
 			totalNegativeIncomeCounter += 1
+			if o.Requesters[id] == 0 {
+				nonOriNegativeIncomeCounter += 1
+			}
 		}
 	}
-	return float64(totalNegativeIncomeCounter) / float64(config.GetNetworkSize())
+	totalNegIncome := float64(totalNegativeIncomeCounter) / float64(config.GetNetworkSize())
+	nonOriNegIncome := 0.0
+	if len(o.Requesters) < config.GetNetworkSize() {
+		nonOriNegIncome = float64(nonOriNegativeIncomeCounter) / float64(config.GetNetworkSize()-len(o.Requesters))
+	}
+
+	return totalNegIncome, nonOriNegIncome
 }
 
 func (ii *IncomeInfo) Update(output *Route) {
@@ -116,7 +139,7 @@ func (ii *IncomeInfo) Update(output *Route) {
 		if !(payment.Payment.IsOriginator) {
 			ii.IncomeMap[payer] -= payment.Price
 		} else {
-			ii.Requesters[payee] = true
+			ii.Requesters[payee]++
 			ii.CostMap[payee] += payment.Price
 			if hop != 0 {
 				panic("First payment in list is not from originator.")
@@ -385,8 +408,13 @@ func (ii *IncomeInfo) Log() {
 	}
 
 	if config.GetNegativeIncome() {
-		negativeIncomeRes := ii.CalculateNegativeIncome()
+		negativeIncomeRes, nonOriNegIncome := ii.CalculateNegativeIncome()
 		_, err := ii.Writer.WriteString(fmt.Sprintf("Negative income: %f %% \n", negativeIncomeRes*100))
+		if err != nil {
+			panic(err)
+		}
+
+		_, err = ii.Writer.WriteString(fmt.Sprintf("Non originators with negative income: %f %% \n", nonOriNegIncome*100))
 		if err != nil {
 			panic(err)
 		}
@@ -404,6 +432,10 @@ func (ii *IncomeInfo) Log() {
 		}
 
 		_, err = ii.Writer.WriteString(fmt.Sprintf("Org Cost fairness: %f \n", ii.CalculateOriginatorCostFairness()))
+		if err != nil {
+			panic(err)
+		}
+		_, err = ii.Writer.WriteString(fmt.Sprintf("Org Utility fairness: %f \n", ii.CalculateCostAdjustedOriginatorIncomeFairness()))
 		if err != nil {
 			panic(err)
 		}

--- a/model/parts/output/output_logic.go
+++ b/model/parts/output/output_logic.go
@@ -22,6 +22,7 @@ type Route struct {
 	AccessFailed       bool
 	ThresholdFailed    bool
 	FoundByCaching     bool
+	RetryCount         int
 }
 
 func (o *Route) failed() bool {

--- a/model/parts/output/worker.go
+++ b/model/parts/output/worker.go
@@ -24,7 +24,7 @@ func Worker(outputChan chan Route, wg *sync.WaitGroup) {
 		for _, logger := range loggers {
 			logger.Update(&outputStruct)
 
-			if counter%logInterval == 0 {
+			if logInterval > 0 && counter%logInterval == 0 {
 				logger.Log()
 				if reset {
 					logger.Reset()
@@ -32,7 +32,9 @@ func Worker(outputChan chan Route, wg *sync.WaitGroup) {
 			}
 		}
 	}
-
+	for _, logger := range loggers {
+		logger.Log()
+	}
 }
 
 func CreateLoggers() []LogResetUpdateCloser {

--- a/model/parts/update/update_reroute.go
+++ b/model/parts/update/update_reroute.go
@@ -2,13 +2,11 @@ package update
 
 import (
 	"go-incentive-simulation/config"
-	"go-incentive-simulation/model/general"
 	"go-incentive-simulation/model/parts/types"
-	"sync/atomic"
 )
 
-func Reroute(state *types.State, requestResult types.RequestResult, curEpoch int) int64 {
-	var retryCounter int64 = 0
+func Reroute(state *types.State, requestResult types.RequestResult, curEpoch int) int {
+	var retryCounter int = 0
 	if config.IsRetryWithAnotherPeer() {
 
 		route := requestResult.Route
@@ -20,6 +18,7 @@ func Reroute(state *types.State, requestResult types.RequestResult, curEpoch int
 		if requestResult.Found {
 			if reroute.RejectedNodes != nil {
 				if reroute.ChunkId == chunkId { // If chunkId == chunkId --> reset reroute
+
 					originator.RerouteStruct.ResetRerouteAndSaveToHistory(chunkId, curEpoch)
 				}
 			}
@@ -28,19 +27,13 @@ func Reroute(state *types.State, requestResult types.RequestResult, curEpoch int
 			lastHopNode := route[len(route)-1]
 			if reroute.RejectedNodes == nil {
 				reroute = originator.RerouteStruct.AddNewReroute(requestResult.AccessFailed, lastHopNode, chunkId, curEpoch)
-				retryCounter = atomic.AddInt64(&state.UniqueRetryCounter, 1)
-			} else {
-				if !general.Contains(reroute.RejectedNodes, lastHopNode) { // if the last hop in new route have not been searched before
-					originator.RerouteStruct.AddNodeToRejectedNodes(requestResult.AccessFailed, lastHopNode, curEpoch)
-				}
 			}
+			originator.RerouteStruct.AddNodeToRejectedNodes(requestResult.AccessFailed, lastHopNode, chunkId, curEpoch)
 		}
 
-		if retryCounter == 0 {
-			retryCounter = atomic.LoadInt64(&state.UniqueRetryCounter)
-		}
+		retryCounter = len(reroute.RejectedNodes)
 
-		if len(reroute.RejectedNodes) > config.GetBinSize() {
+		if len(reroute.RejectedNodes) >= config.GetBinSize() {
 			originator.RerouteStruct.ResetRerouteAndSaveToHistory(chunkId, curEpoch)
 		}
 

--- a/model/parts/workers/request_worker.go
+++ b/model/parts/workers/request_worker.go
@@ -12,10 +12,11 @@ import (
 func RequestWorker(pauseChan chan bool, continueChan chan bool, requestChan chan types.Request, globalState *types.State, wg *sync.WaitGroup) {
 
 	defer wg.Done()
-	var requestQueueSize = 10
-	var counter = 0
-	var curEpoch = 0
+	requestQueueSize := 10
+	counter := 0
+	curEpoch := 0
 	var chunkId types.ChunkId
+	timeStep := 0
 	iterations := config.GetIterations()
 	numRoutingGoroutines := config.GetNumRoutingGoroutines()
 
@@ -23,14 +24,6 @@ func RequestWorker(pauseChan chan bool, continueChan chan bool, requestChan chan
 
 	for counter < iterations {
 		if len(requestChan) <= requestQueueSize {
-
-			timeStep := update.TimeStep(globalState)
-
-			if config.TimeForNewEpoch(timeStep) {
-				curEpoch = update.Epoch(globalState)
-
-				waitForRoutingWorkers(pauseChan, continueChan, numRoutingGoroutines)
-			}
 
 			originatorIndex := int(update.OriginatorIndex(globalState, timeStep))
 			originatorId := globalState.GetOriginatorId(originatorIndex)
@@ -44,6 +37,17 @@ func RequestWorker(pauseChan chan bool, continueChan chan bool, requestChan chan
 
 				if len(rerouteStruct.Reroute.RejectedNodes) > 0 {
 					chunkId = rerouteStruct.Reroute.ChunkId
+				}
+			}
+
+			if chunkId == -1 || config.RetryCausesTimeIncrease() {
+				// do not count retries towards second load.
+				timeStep = update.TimeStep(globalState)
+
+				if config.TimeForNewEpoch(timeStep) {
+					curEpoch = update.Epoch(globalState)
+
+					waitForRoutingWorkers(pauseChan, continueChan, numRoutingGoroutines)
 				}
 			}
 
@@ -87,6 +91,9 @@ func RequestWorker(pauseChan chan bool, continueChan chan bool, requestChan chan
 
 			if config.TimeForDebugPrints(timeStep) {
 				fmt.Println("TimeStep is currently:", timeStep)
+			}
+			if config.TimeForDebugPrints(counter) {
+				fmt.Println("Counter is currently:", counter)
 			}
 		}
 	}

--- a/model/routing/routing.go
+++ b/model/routing/routing.go
@@ -40,7 +40,6 @@ func getNext(request types.Request, firstNodeId types.NodeId, prevNodePaid bool,
 		}
 
 		if !IsThresholdFailed(firstNodeId, nodeId, graph, request) {
-			thresholdFailed = false
 
 			if config.IsRetryWithAnotherPeer() {
 				rerouteStruct := graph.GetNode(mainOriginatorId).RerouteStruct
@@ -52,11 +51,15 @@ func getNext(request types.Request, firstNodeId types.NodeId, prevNodePaid bool,
 				}
 			}
 
+			thresholdFailed = false
+
 			if config.IsEdgeLock() {
 				if !nextNodeId.IsNil() {
+					// found new nextNode, release lock on previous found.
 					graph.UnlockEdge(firstNodeId, nextNodeId)
 				}
 				if !payNextId.IsNil() {
+					// found new nextNode, without payment, release lock on previous found payNext.
 					graph.UnlockEdge(firstNodeId, payNextId)
 					payNextId = -1 // IMPORTANT!
 				}
@@ -104,6 +107,9 @@ func getNext(request types.Request, firstNodeId types.NodeId, prevNodePaid bool,
 				payment.PayNextId = payNextId
 				payment.ChunkId = chunkId
 				nextNodeId = payNextId
+				thresholdFailed = false
+			} else if config.IsEdgeLock() {
+				graph.UnlockEdge(firstNodeId, payNextId)
 			}
 		} else if config.IsPayIfOrigPays() {
 			// Pay if the originator pays or if the previous node has paid
@@ -113,8 +119,8 @@ func getNext(request types.Request, firstNodeId types.NodeId, prevNodePaid bool,
 				payment.ChunkId = chunkId
 				nextNodeId = payNextId
 				thresholdFailed = false
-			} else {
-				thresholdFailed = true
+			} else if config.IsEdgeLock() {
+				graph.UnlockEdge(firstNodeId, payNextId)
 			}
 		} else {
 			// Always pays

--- a/model/routing/routing_worker.go
+++ b/model/routing/routing_worker.go
@@ -48,7 +48,7 @@ func RoutingWorker(pauseChan chan bool, continueChan chan bool, requestChan chan
 			output := update.Graph(globalState, requestResult, curTimeStep)
 
 			update.Pending(globalState, requestResult, request.Epoch)
-			update.Reroute(globalState, requestResult, request.Epoch)
+			output.RetryCount = update.Reroute(globalState, requestResult, request.Epoch)
 			update.Cache(globalState, requestResult)
 
 			if config.IsOutputEnabled() {


### PR DESCRIPTION
* Retry can be used with threshold failures.
* Only access failures are safe in the retry structs history.
* The output struct indicates if an output is the result of a retry
* A config option was added to determine if retries cause time to increase. Default option is retires do not cost time.
* If the uniqueChunk per iteration option is used, the output worker may receive more outputs than Iterations, since retries cause outputs, but do not count towards iterations. The output/worker is adjusted to ensure a log statement at the end of the experiment.
Additional unrelated feature included is some more metrics for income of originators.
First I try to compute the gini coefficient to see how fair the prices are, i.e. if some originators pay more for downloading than other.
Second I compute the gini coefficient over a metric that combines both income and download utility of originators.
Download utility is computed as maximum (chunk price - payed chunk price) per chunk.