### PR TITLE
More options

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -55,7 +55,7 @@ BaseOptions:
     MeanRewardPerForward: false
     AverageNumberOfHops: false
     HopFractionOfTotalRewards: false
-    NegaticeIncome: false
+    NegativeIncome: false
     IncomeGini: true
     IncomeTheil: false
     HopIncome: false

--- a/config/config_types.go
+++ b/config/config_types.go
@@ -54,6 +54,7 @@ type experimentOptions struct {
 	CacheIsEnabled                    bool `yaml:"CacheIsEnabled"`
 	PreferredChunks                   bool `yaml:"PreferredChunks"`
 	AdjustableThreshold               bool `yaml:"AdjustableThreshold"`
+	VariableRefreshrate               bool `yaml:VariableRefreshrate`
 	PayIfOrigPays                     bool `yaml:"PayIfOrigPays"`
 }
 

--- a/config/config_types.go
+++ b/config/config_types.go
@@ -54,8 +54,9 @@ type experimentOptions struct {
 	CacheIsEnabled                    bool `yaml:"CacheIsEnabled"`
 	PreferredChunks                   bool `yaml:"PreferredChunks"`
 	AdjustableThreshold               bool `yaml:"AdjustableThreshold"`
-	VariableRefreshrate               bool `yaml:VariableRefreshrate`
+	VariableRefreshrate               bool `yaml:"VariableRefreshrate"`
 	PayIfOrigPays                     bool `yaml:"PayIfOrigPays"`
+	RouteOnlyNearest                  bool `yaml:"RouteOnlyNearest"`
 }
 
 type outputOptions struct {

--- a/config/default_variables.go
+++ b/config/default_variables.go
@@ -66,6 +66,7 @@ func getDefaultConfig() Config {
 			PreferredChunks:                   false, // false
 			AdjustableThreshold:               false, // false
 			VariableRefreshrate:               false, // false
+			RouteOnlyNearest:                  false, // false
 		},
 	}
 }

--- a/config/default_variables.go
+++ b/config/default_variables.go
@@ -65,6 +65,7 @@ func getDefaultConfig() Config {
 			CacheIsEnabled:                    false, // false
 			PreferredChunks:                   false, // false
 			AdjustableThreshold:               false, // false
+			VariableRefreshrate:               false, // false
 		},
 	}
 }

--- a/config/get_variables.go
+++ b/config/get_variables.go
@@ -31,6 +31,10 @@ func IsAdjustableThreshold() bool {
 	return theconfig.ExperimentOptions.AdjustableThreshold
 }
 
+func IsVariableRefreshrate() bool {
+	return theconfig.ExperimentOptions.VariableRefreshrate
+}
+
 func GetAdjustableThresholdExponent() int {
 	return theconfig.BaseOptions.AdjustableThresholdExponent
 }

--- a/config/get_variables.go
+++ b/config/get_variables.go
@@ -75,6 +75,10 @@ func IsPayIfOrigPays() bool {
 	return theconfig.ExperimentOptions.PayIfOrigPays
 }
 
+func IsRouteOnlyNearest() bool {
+	return theconfig.ExperimentOptions.RouteOnlyNearest
+}
+
 func IsPayOnlyForCurrentRequest() bool {
 	return theconfig.ExperimentOptions.PayOnlyForCurrentRequest
 }
@@ -325,6 +329,12 @@ func GetExperimentString() (exp string) {
 	}
 	if IsAdjustableThreshold() {
 		exp += "FgAdj"
+	}
+	if !IsPayOnlyForCurrentRequest() {
+		exp += "FullDept"
+	}
+	if IsRouteOnlyNearest() {
+		exp += "Nearest"
 	}
 
 	exp += "-" + GetExpeimentId()

--- a/config/init_configs.go
+++ b/config/init_configs.go
@@ -14,8 +14,8 @@ import (
 // theconfig This is the current configuration.
 var theconfig Config
 
-func InitConfig() {
-	config, err := ReadYamlFile("config.yaml")
+func InitConfig(configfile string) {
+	config, err := ReadYamlFile(configfile)
 	if err != nil {
 		log.Panicln("Unable to read config file: config.yaml")
 	}

--- a/generate_network_data/README.md
+++ b/generate_network_data/README.md
@@ -1,0 +1,7 @@
+To generate a network with the second choice option, you need to use the `config` parameter.
+E.g.
+```bash
+cd generate_network_data
+go build
+./generate_network_data -random=false -config=true -conffile=../config.yaml
+```

--- a/generate_network_data/generate_data.go
+++ b/generate_network_data/generate_data.go
@@ -21,11 +21,12 @@ func main() {
 	count := flag.Int("count", -1, "generate count many networks with ids i0,i1,...")
 	random := flag.Bool("random", true, "spread nodes randomly")
 	useconfig := flag.Bool("config", false, "use config.yaml to initialize bits, binSize, NetworkSize and randomness")
+	conffile := flag.String("conffile", "config.yaml", "specify config file")
 
 	flag.Parse()
 
 	if *useconfig {
-		config.InitConfig("config.yaml")
+		config.InitConfig(*conffile)
 		*binSize = config.GetBinSize()
 		*bits = config.GetBits()
 		*networkSize = config.GetNetworkSize()

--- a/generate_network_data/generate_data.go
+++ b/generate_network_data/generate_data.go
@@ -25,7 +25,7 @@ func main() {
 	flag.Parse()
 
 	if *useconfig {
-		config.InitConfig()
+		config.InitConfig("config.yaml")
 		*binSize = config.GetBinSize()
 		*bits = config.GetBits()
 		*networkSize = config.GetNetworkSize()

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ import (
 )
 
 func main() {
+	configfile := flag.String("conf", "config.yaml", "path to config file to use")
 	graphId := flag.String("graphId", "", "an Id for the graph, e.g. even")
 	count := flag.Int("count", -1, "run for different networks with ids i0,i1,...")
 	maxPOs := flag.String("maxPOs", "", "min:max maxPO value")
@@ -46,18 +47,18 @@ func main() {
 
 	for maxPO := min; maxPO < max; maxPO++ {
 		if *count < 0 {
-			run(-1, *graphId, maxPO)
+			run(-1, *graphId, maxPO, *configfile)
 		}
 		for i := 0; i < *count; i++ {
-			run(i, *graphId, maxPO)
+			run(i, *graphId, maxPO, *configfile)
 		}
 	}
 
 }
 
-func run(iteration int, graphId string, maxPO int) {
+func run(iteration int, graphId string, maxPO int, configfile string) {
 	start := time.Now()
-	config.InitConfig()
+	config.InitConfig(configfile)
 	if maxPO > -1 {
 		config.SetMaxPO(maxPO)
 	}

--- a/model/parts/types/graph.go
+++ b/model/parts/types/graph.go
@@ -165,6 +165,14 @@ func (g *Graph) unsafeEdgeExists(fromNodeId NodeId, toNodeId NodeId) bool {
 	return false
 }
 
+func (g *Graph) SetEdgeA2B(fromNodeId NodeId, toNodeId NodeId, a2b int) bool {
+	if g.EdgeExists(fromNodeId, toNodeId) {
+		g.Edges[fromNodeId][toNodeId].Attrs.A2B = a2b
+		return true
+	}
+	return false
+}
+
 func (g *Graph) SetEdgeData(fromNodeId NodeId, toNodeId NodeId, edgeAttrs EdgeAttrs) bool {
 	if g.EdgeExists(fromNodeId, toNodeId) {
 		g.Edges[fromNodeId][toNodeId].Attrs = edgeAttrs

--- a/model/parts/types/network.go
+++ b/model/parts/types/network.go
@@ -165,6 +165,7 @@ func (network *Network) Generate(count int, random bool) []*Node {
 	nodeIds := generateIds(count, (1<<network.Bits)-1)
 	if !random {
 		if config.GetBits() > 0 {
+			fmt.Println("second choice!")
 			nodeIds = generateIdsSecondChoice(count, (1<<network.Bits)-1)
 		} else {
 			nodeIds = generateIdsEven(count, (1<<network.Bits)-1)

--- a/model/parts/update/update_graph.go
+++ b/model/parts/update/update_graph.go
@@ -27,15 +27,17 @@ func Graph(state *types.State, requestResult types.RequestResult, curTimeStep in
 				}
 				if actualPrice < 0 {
 					continue
+				}
+				if !config.IsPayOnlyForCurrentRequest() {
+					state.Graph.SetEdgeA2B(payment.FirstNodeId, payment.PayNextId, 0)
+					state.Graph.SetEdgeA2B(payment.PayNextId, payment.FirstNodeId, 0)
 				} else {
-					if !config.IsPayOnlyForCurrentRequest() {
-						state.Graph.SetEdgeA2B(payment.FirstNodeId, payment.PayNextId, 0)
-						state.Graph.SetEdgeA2B(payment.PayNextId, payment.FirstNodeId, 0)
-					} else {
-						// Important fix: Reduce debt here, since it debt will be added again below.
-						// Idea is, paying for the current request should not effect the edge balance.
-						state.Graph.SetEdgeA2B(payment.FirstNodeId, payment.PayNextId, edgeData1.A2B-price)
-					}
+					// Important fix: Reduce debt here, since it debt will be added again below.
+					// Idea is, paying for the current request should not effect the edge balance.
+					state.Graph.SetEdgeA2B(payment.FirstNodeId, payment.PayNextId, edgeData1.A2B-price)
+				}
+				if config.IsVariableRefreshrate() {
+					state.Graph.SetEdgeIncrementThreshold(payment.FirstNodeId, payment.PayNextId)
 				}
 				// fmt.Println("Payment from ", payment.FirstNodeId, " to ", payment.PayNextId, " for chunk ", payment.ChunkId, " with price ", actualPrice)
 				paymentWithPrice = types.PaymentWithPrice{Payment: payment, Price: actualPrice}

--- a/model/parts/update/update_graph.go
+++ b/model/parts/update/update_graph.go
@@ -29,19 +29,12 @@ func Graph(state *types.State, requestResult types.RequestResult, curTimeStep in
 					continue
 				} else {
 					if !config.IsPayOnlyForCurrentRequest() {
-						newEdgeData1 := edgeData1
-						newEdgeData1.A2B = 0
-						state.Graph.SetEdgeData(payment.FirstNodeId, payment.PayNextId, newEdgeData1)
-
-						newEdgeData2 := edgeData2
-						newEdgeData2.A2B = 0
-						state.Graph.SetEdgeData(payment.PayNextId, payment.FirstNodeId, newEdgeData2)
+						state.Graph.SetEdgeA2B(payment.FirstNodeId, payment.PayNextId, 0)
+						state.Graph.SetEdgeA2B(payment.PayNextId, payment.FirstNodeId, 0)
 					} else {
 						// Important fix: Reduce debt here, since it debt will be added again below.
 						// Idea is, paying for the current request should not effect the edge balance.
-						newEdgeData1 := edgeData1
-						newEdgeData1.A2B = edgeData1.A2B - price
-						state.Graph.SetEdgeData(payment.FirstNodeId, payment.PayNextId, newEdgeData1)
+						state.Graph.SetEdgeA2B(payment.FirstNodeId, payment.PayNextId, edgeData1.A2B-price)
 					}
 				}
 				// fmt.Println("Payment from ", payment.FirstNodeId, " to ", payment.PayNextId, " for chunk ", payment.ChunkId, " with price ", actualPrice)
@@ -58,9 +51,7 @@ func Graph(state *types.State, requestResult types.RequestResult, curTimeStep in
 			providerNode := route[i+1]
 			price := utils.PeerPriceChunk(providerNode, chunkId)
 			edgeData := state.Graph.GetEdgeData(requesterNode, providerNode)
-			newEdgeData := edgeData
-			newEdgeData.A2B += price
-			state.Graph.SetEdgeData(requesterNode, providerNode, newEdgeData)
+			state.Graph.SetEdgeA2B(requesterNode, providerNode, edgeData.A2B+price)
 
 			if config.GetMaxPOCheckEnabled() {
 				nodePairWithPrice = types.NodePairWithPrice{RequesterNode: requesterNode, ProviderNode: providerNode, Price: price}

--- a/model/parts/utils/utils.go
+++ b/model/parts/utils/utils.go
@@ -41,9 +41,7 @@ func CreateGraphNetwork(net *types.Network) (*types.Graph, error) {
 		nodeAdj := node.AdjIds
 		for _, adjItems := range nodeAdj {
 			for _, otherNodeId := range adjItems {
-				threshold := general.BitLength(nodeId.ToInt() ^ otherNodeId.ToInt())
-				attrs := types.EdgeAttrs{A2B: 0, LastEpoch: 0, Threshold: threshold}
-				err := graph.AddEdge(node.Id, otherNodeId, attrs)
+				err := graph.AddEdge(node.Id, otherNodeId)
 				if err != nil {
 					return nil, err
 				}

--- a/model/routing/forgiveness.go
+++ b/model/routing/forgiveness.go
@@ -1,9 +1,7 @@
 package routing
 
 import (
-	"go-incentive-simulation/config"
 	"go-incentive-simulation/model/parts/types"
-	"math"
 )
 
 func CheckForgiveness(edgeData types.EdgeAttrs, firstNodeId types.NodeId, secondNodeId types.NodeId, graph *types.Graph, request types.Request) (int, bool) {
@@ -13,10 +11,7 @@ func CheckForgiveness(edgeData types.EdgeAttrs, firstNodeId types.NodeId, second
 		return edgeData.A2B, false
 	}
 
-	refreshRate := config.GetRefreshRate()
-	if config.IsAdjustableThreshold() {
-		refreshRate = GetAdjustedRefreshrate(edgeData.Threshold, config.GetThreshold(), config.GetRefreshRate(), config.GetAdjustableThresholdExponent())
-	}
+	refreshRate := edgeData.Refreshrate
 
 	removedDeptAmount := passedTime * refreshRate
 	newEdgeData := edgeData
@@ -28,9 +23,4 @@ func CheckForgiveness(edgeData types.EdgeAttrs, firstNodeId types.NodeId, second
 	graph.SetEdgeData(firstNodeId, secondNodeId, newEdgeData)
 
 	return newEdgeData.A2B, true
-}
-
-func GetAdjustedRefreshrate(adjustedThreshold, threshold, refreshRate, power int) int {
-	ratio := float64(adjustedThreshold) / float64(threshold)
-	return int(math.Ceil(float64(refreshRate) * math.Pow(ratio, float64(power))))
 }

--- a/model/routing/forgiveness.go
+++ b/model/routing/forgiveness.go
@@ -1,6 +1,7 @@
 package routing
 
 import (
+	"go-incentive-simulation/config"
 	"go-incentive-simulation/model/parts/types"
 )
 
@@ -21,6 +22,9 @@ func CheckForgiveness(edgeData types.EdgeAttrs, firstNodeId types.NodeId, second
 	}
 	newEdgeData.LastEpoch = request.Epoch
 	graph.SetEdgeData(firstNodeId, secondNodeId, newEdgeData)
+	if config.IsVariableRefreshrate() {
+		graph.SetEdgeDecrementThreshold(firstNodeId, secondNodeId)
+	}
 
 	return newEdgeData.A2B, true
 }

--- a/model/routing/threshold.go
+++ b/model/routing/threshold.go
@@ -16,10 +16,7 @@ func IsThresholdFailed(firstNodeId types.NodeId, secondNodeId types.NodeId, grap
 	edgeDataSecond := graph.GetEdgeData(secondNodeId, firstNodeId)
 	p2pSecond := edgeDataSecond.A2B
 
-	threshold := config.GetThreshold()
-	if config.IsAdjustableThreshold() {
-		threshold = edgeDataFirst.Threshold
-	}
+	threshold := edgeDataFirst.Threshold
 
 	peerPriceChunk := utils.PeerPriceChunk(secondNodeId, request.ChunkId)
 


### PR DESCRIPTION
This cointains some more options for paying and generating networks:

**Refactoring:**
- Handling adjusted threshold is moved into the types package

**Configurable config options**
- `RouteOnlyNearest` will always use the neighbor closest to the chunk, even if others have free bandwidth and this one needs to be payed.
- `VariableRefreshrate` increases and decreases the refreshrate on paying and refreshing. Not sure this is useful. Should probably be removed.

**Command line options**
- `conf` parameter allows to specify a specific config file. I find this useful, when I need to plan multiple runs, because I can run them without changing the config file in between, e.g.:
```
./go-incentive-simulation -conf=firstfile.yaml -graphId=secondChoice
```

**Options for network generation**
- `config`: tell the tool to use network size, bin size and bits from a configuration file.
- `conffile`: give the relative path to a config file to be used.
- **If the `-random=false` options is used together with the `-config` the tool will use the second choice rule for generating node Ids. In this rule, for every node, two random IDs are chosen and the one with fewer peers already in the neighborhood is chosen.
See also `generate_network_data/README.md`.